### PR TITLE
feat: auto OAuth prompt and blogId resolution from URL

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,11 +5,86 @@ import { clearUserHatena, getUserState, saveUserBlog, storeOAuthState } from '..
 import { buildAuthorizeUrl, createEntry, getRequestToken, listEntries, updateEntry } from '../lib/hatena';
 import * as z from 'zod';
 
-function ensureHatenaSession(state: Awaited<ReturnType<typeof getUserState>>) {
+type HatenaSession = {
+  accessToken: string;
+  accessSecret: string;
+  hatenaId: string;
+  blogs?: import('../types').BlogInfo[];
+};
+
+function ensureHatenaSession(state: Awaited<ReturnType<typeof getUserState>>): HatenaSession {
   if (!state?.hatena || !state.hatena.hatenaId) {
     throw new Error('Hatena account not linked');
   }
-  return state.hatena as Required<NonNullable<typeof state>['hatena']>;
+  return state.hatena as HatenaSession;
+}
+
+/**
+ * Extract blogId and optional entryId from a Hatena URL.
+ *
+ * Supported patterns:
+ *   https://nagwiki.hatenadiary.org/entry/...   → blogId only
+ *   https://blog.hatena.ne.jp/{user}/{blogId}/edit?entry={entryId} → blogId + entryId
+ */
+function parseHatenaUrl(url: string): { blogId: string; entryId?: string } | null {
+  try {
+    const parsed = new URL(url);
+    // Admin edit URL: blog.hatena.ne.jp/{user}/{blogId}/edit?entry={entryId}
+    if (parsed.hostname === 'blog.hatena.ne.jp') {
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      const blogId = segments[1];
+      const entryId = parsed.searchParams.get('entry') ?? undefined;
+      if (!blogId) return null;
+      return { blogId, entryId };
+    }
+    // Blog entry URL: {blogId}/entry/...
+    return { blogId: parsed.hostname };
+  } catch {
+    return null;
+  }
+}
+
+async function buildOAuthStartResponse(env: Env, userId: string, requestUrl: string) {
+  const state = crypto.randomUUID();
+  const callbackUrl = new URL('/hatena/oauth/callback', requestUrl).toString();
+  const { requestToken, requestTokenSecret } = await getRequestToken(env, callbackUrl);
+  const record = { userId, requestToken, requestTokenSecret, createdAt: new Date().toISOString() };
+  await storeOAuthState(env, state, record);
+  await storeOAuthState(env, requestToken, record);
+  const authorizeUrl = buildAuthorizeUrl(requestToken, state);
+  return {
+    content: [{
+      type: 'text' as const,
+      text: `Hatena account not linked. Please visit the following URL to authorize:\n${authorizeUrl}`,
+    }],
+  };
+}
+
+/**
+ * Resolve blogId from args. Priority:
+ *   1. args.blogId directly provided
+ *   2. args.url provided → extract hostname or blog.hatena.ne.jp path segment
+ *   3. first saved blog in user state
+ * Returns null if none found, along with an optional entryId from the URL.
+ */
+async function resolveBlogId(
+  env: Env,
+  userId: string,
+  args: { blogId?: string; url?: string },
+): Promise<{ blogId: string | null; entryIdFromUrl?: string }> {
+  if (args.blogId) return { blogId: args.blogId };
+
+  if (args.url) {
+    const parsed = parseHatenaUrl(args.url);
+    if (parsed) {
+      await saveUserBlog(env, userId, { blogId: parsed.blogId, url: args.url });
+      return { blogId: parsed.blogId, entryIdFromUrl: parsed.entryId };
+    }
+  }
+
+  const state = await getUserState(env, userId);
+  const saved = state?.hatena?.blogs?.[0]?.blogId ?? null;
+  return { blogId: saved };
 }
 
 export function buildMcpServer(env: Env, userId: string, requestUrl: string) {
@@ -59,20 +134,31 @@ export function buildMcpServer(env: Env, userId: string, requestUrl: string) {
     'list_entries',
     {
       title: 'List Hatena blog entries',
-      description: 'Fetches entries for a blog ID.',
+      description: 'Fetches entries for a blog. Pass blogId, a Hatena blog URL, or omit to use the saved blog.',
       inputSchema: z.object({
-        blogId: z.string(),
+        blogId: z.string().optional(),
+        url: z.string().optional(),
         limit: z.number().optional(),
         offset: z.number().optional(),
       }),
     },
     async (args) => {
       try {
-        const hatena = ensureHatenaSession(await getUserState(env, userId));
+        const userState = await getUserState(env, userId);
+        if (!userState?.hatena?.hatenaId) return buildOAuthStartResponse(env, userId, requestUrl);
+        const hatena = userState.hatena as ReturnType<typeof ensureHatenaSession>;
+
+        const { blogId } = await resolveBlogId(env, userId, args);
+        if (!blogId) {
+          return {
+            content: [{ type: 'text', text: 'No blog registered yet. Please provide your Hatena blog URL and I\'ll register it automatically.' }],
+          };
+        }
+
         const data = await listEntries(
           env,
           { accessToken: hatena.accessToken, accessSecret: hatena.accessSecret, hatenaId: hatena.hatenaId },
-          args.blogId,
+          blogId,
           { limit: args.limit, offset: args.offset },
         );
         return { content: [{ type: 'text', text: JSON.stringify(data) }], structuredContent: data };
@@ -86,9 +172,10 @@ export function buildMcpServer(env: Env, userId: string, requestUrl: string) {
     'create_entry',
     {
       title: 'Create Hatena blog entry',
-      description: 'Creates a new entry.',
+      description: 'Creates a new entry. Pass blogId, a Hatena blog URL, or omit to use the saved blog.',
       inputSchema: z.object({
-        blogId: z.string(),
+        blogId: z.string().optional(),
+        url: z.string().optional(),
         title: z.string(),
         content: z.string(),
         draft: z.boolean().optional(),
@@ -96,11 +183,21 @@ export function buildMcpServer(env: Env, userId: string, requestUrl: string) {
     },
     async (args) => {
       try {
-        const hatena = ensureHatenaSession(await getUserState(env, userId));
+        const userState = await getUserState(env, userId);
+        if (!userState?.hatena?.hatenaId) return buildOAuthStartResponse(env, userId, requestUrl);
+        const hatena = userState.hatena as ReturnType<typeof ensureHatenaSession>;
+
+        const { blogId } = await resolveBlogId(env, userId, args);
+        if (!blogId) {
+          return {
+            content: [{ type: 'text', text: 'No blog registered yet. Please provide your Hatena blog URL and I\'ll register it automatically.' }],
+          };
+        }
+
         const result = await createEntry(
           env,
           { accessToken: hatena.accessToken, accessSecret: hatena.accessSecret, hatenaId: hatena.hatenaId },
-          args.blogId,
+          blogId,
           { title: args.title, content: args.content, draft: args.draft },
         );
         return { content: [{ type: 'text', text: JSON.stringify(result) }], structuredContent: result };
@@ -114,10 +211,11 @@ export function buildMcpServer(env: Env, userId: string, requestUrl: string) {
     'update_entry',
     {
       title: 'Update Hatena blog entry',
-      description: 'Updates an existing entry.',
+      description: 'Updates an existing entry. Pass the Hatena admin edit URL (https://blog.hatena.ne.jp/{user}/{blogId}/edit?entry={entryId}) to auto-extract blogId and entryId, or provide them directly.',
       inputSchema: z.object({
-        blogId: z.string(),
-        entryId: z.string(),
+        blogId: z.string().optional(),
+        entryId: z.string().optional(),
+        url: z.string().optional(),
         title: z.string().optional(),
         content: z.string().optional(),
         draft: z.boolean().optional(),
@@ -125,12 +223,33 @@ export function buildMcpServer(env: Env, userId: string, requestUrl: string) {
     },
     async (args) => {
       try {
-        const hatena = ensureHatenaSession(await getUserState(env, userId));
+        const userState = await getUserState(env, userId);
+        if (!userState?.hatena?.hatenaId) return buildOAuthStartResponse(env, userId, requestUrl);
+        const hatena = userState.hatena as ReturnType<typeof ensureHatenaSession>;
+
+        const { blogId, entryIdFromUrl } = await resolveBlogId(env, userId, args);
+        const entryId = args.entryId ?? entryIdFromUrl;
+
+        if (!blogId) {
+          return {
+            content: [{ type: 'text', text: 'No blog registered yet. Please provide your Hatena blog URL and I\'ll register it automatically.' }],
+          };
+        }
+
+        if (!entryId) {
+          return {
+            content: [{
+              type: 'text',
+              text: 'Could not determine the entry ID. Please provide the Hatena admin edit URL in the format:\nhttps://blog.hatena.ne.jp/{username}/{blogId}/edit?entry={entryId}',
+            }],
+          };
+        }
+
         const result = await updateEntry(
           env,
           { accessToken: hatena.accessToken, accessSecret: hatena.accessSecret, hatenaId: hatena.hatenaId },
-          args.blogId,
-          args.entryId,
+          blogId,
+          entryId,
           { title: args.title, content: args.content, draft: args.draft },
         );
         return { content: [{ type: 'text', text: JSON.stringify(result) }], structuredContent: result };


### PR DESCRIPTION
## Summary
- Blog operations (`list_entries`, `create_entry`, `update_entry`) now auto-prompt for OAuth when Hatena account is not linked, returning the authorization URL instead of a raw error
- `blogId` and `url` are now optional on all entry tools; passing a Hatena blog URL automatically extracts and registers the blogId
- `update_entry` accepts the Hatena admin edit URL (`https://blog.hatena.ne.jp/{user}/{blogId}/edit?entry={entryId}`) to auto-extract both `blogId` and `entryId`
- When no blogId is registered and no URL is provided, a clear message guides the user to provide their blog URL

## Test plan
- [ ] Call `list_entries` with no args on a fresh session → should return OAuth authorization URL
- [ ] Call `list_entries` with a blog entry URL → should auto-register blogId and return entries
- [ ] Call `update_entry` with an admin edit URL → should auto-extract blogId + entryId and update
- [ ] Call `list_entries` with no args after OAuth but no saved blog → should ask for blog URL

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)