### PR TITLE
feat: add get_entry MCP tool

### DIFF
--- a/src/lib/hatena.ts
+++ b/src/lib/hatena.ts
@@ -205,6 +205,25 @@ export async function createEntry(env: Env, user: { accessToken: string; accessS
   return { raw: text };
 }
 
+export async function getEntry(env: Env, user: { accessToken: string; accessSecret: string; hatenaId: string }, blogId: string, entryId: string) {
+  const url = `${entryFeedUrl(user.hatenaId, blogId)}/${entryId}`;
+  const resp = await signedAtomRequest(env, user, 'GET', url);
+  const text = await resp.text();
+  if (!resp.ok) throw new Error(`Hatena get entry failed: ${resp.status} ${text}`);
+  const parsed = await parseStringPromise(text, { explicitArray: false, explicitRoot: false });
+  return {
+    raw: text,
+    entry: {
+      id: parsed.id,
+      title: parsed.title,
+      updated: parsed.updated,
+      published: parsed.published,
+      content: parsed.content?._ ?? parsed.content,
+      draft: parsed['app:control']?.['app:draft'] === 'yes',
+    },
+  };
+}
+
 export async function updateEntry(env: Env, user: { accessToken: string; accessSecret: string; hatenaId: string }, blogId: string, entryId: string, input: { title?: string; content?: string; draft?: boolean }) {
   const url = `${entryFeedUrl(user.hatenaId, blogId)}/${entryId}`;
   // minimal: require title/content provided; otherwise leave empty

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { Env } from '../types';
 import { clearUserHatena, getUserState, saveUserBlog, storeOAuthState } from '../lib/state';
-import { buildAuthorizeUrl, createEntry, getRequestToken, listEntries, updateEntry } from '../lib/hatena';
+import { buildAuthorizeUrl, createEntry, getEntry, getRequestToken, listEntries, updateEntry } from '../lib/hatena';
 import * as z from 'zod';
 
 type HatenaSession = {
@@ -203,6 +203,54 @@ export function buildMcpServer(env: Env, userId: string, requestUrl: string) {
         return { content: [{ type: 'text', text: JSON.stringify(result) }], structuredContent: result };
       } catch (e: any) {
         return { content: [{ type: 'text', text: e?.message ?? 'create_entry failed' }], isError: true };
+      }
+    }
+  );
+
+  server.registerTool(
+    'get_entry',
+    {
+      title: 'Get Hatena blog entry',
+      description: 'Fetches a single entry by entryId. Pass the Hatena admin edit URL (https://blog.hatena.ne.jp/{user}/{blogId}/edit?entry={entryId}) to auto-extract blogId and entryId, or provide them directly.',
+      inputSchema: z.object({
+        blogId: z.string().optional(),
+        entryId: z.string().optional(),
+        url: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      try {
+        const userState = await getUserState(env, userId);
+        if (!userState?.hatena?.hatenaId) return buildOAuthStartResponse(env, userId, requestUrl);
+        const hatena = userState.hatena as ReturnType<typeof ensureHatenaSession>;
+
+        const { blogId, entryIdFromUrl } = await resolveBlogId(env, userId, args);
+        const entryId = args.entryId ?? entryIdFromUrl;
+
+        if (!blogId) {
+          return {
+            content: [{ type: 'text', text: 'No blog registered yet. Please provide your Hatena blog URL and I\'ll register it automatically.' }],
+          };
+        }
+
+        if (!entryId) {
+          return {
+            content: [{
+              type: 'text',
+              text: 'Could not determine the entry ID. Please provide the Hatena admin edit URL in the format:\nhttps://blog.hatena.ne.jp/{username}/{blogId}/edit?entry={entryId}',
+            }],
+          };
+        }
+
+        const result = await getEntry(
+          env,
+          { accessToken: hatena.accessToken, accessSecret: hatena.accessSecret, hatenaId: hatena.hatenaId },
+          blogId,
+          entryId,
+        );
+        return { content: [{ type: 'text', text: JSON.stringify(result) }], structuredContent: result };
+      } catch (e: any) {
+        return { content: [{ type: 'text', text: e?.message ?? 'get_entry failed' }], isError: true };
       }
     }
   );


### PR DESCRIPTION
## Summary

- `src/lib/hatena.ts` に `getEntry()` 関数を追加（AtomPub `GET /atom/entry/{entryId}`）
- `src/mcp/server.ts` に `get_entry` MCPツールを登録
- `update_entry` と同様に、はてな管理画面URLから `blogId`・`entryId` を自動抽出可能

## Test plan

- [ ] はてな管理画面URL（`https://blog.hatena.ne.jp/{user}/{blogId}/edit?entry={entryId}`）を渡して記事が取得できる
- [ ] `blogId` + `entryId` を直接渡しても動作する
- [ ] 未認証時に OAuth 認証URLが返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)